### PR TITLE
Updated the create_table_definition method to accept an explicit tabl…

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_creation.rb
@@ -7,7 +7,7 @@ module ActiveRecord
         private
 
           def visit_ColumnDefinition(o)
-            if [:blob, :clob, :nclob].include?(sql_type = type_to_sql(o.type,  o.options).downcase.to_sym)
+            if [:blob, :clob, :nclob].include?(sql_type = type_to_sql(o.type,  **o.options).downcase.to_sym)
               if (tablespace = default_tablespace_for(sql_type))
                 @lob_tablespaces ||= {}
                 @lob_tablespaces[o.name] = tablespace

--- a/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/schema_statements.rb
@@ -198,7 +198,7 @@ module ActiveRecord
 
         def create_table(table_name, **options)
           create_sequence = options[:id] != false
-          td = create_table_definition table_name, options
+          td = create_table_definition table_name, **options
 
           if options[:id] != false && !options[:as]
             pk = options.fetch(:primary_key) do
@@ -619,8 +619,8 @@ module ActiveRecord
             OracleEnhanced::SchemaCreation.new self
           end
 
-          def create_table_definition(*args)
-            OracleEnhanced::TableDefinition.new(self, *args)
+          def create_table_definition(table_name, **args)
+            OracleEnhanced::TableDefinition.new(self, table_name, **args)
           end
 
           def new_column_from_field(table_name, field)


### PR DESCRIPTION
…e_name and splatted the options being passed through to make sure they are recognised as keyword arguments in ruby 3